### PR TITLE
Implement IntoData for ref mut slice

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -562,7 +562,7 @@ impl<'a> IntoData<'a> for &'a mut [u8] {
     type Output = Data<'a>;
 
     fn into_data(self) -> Result<Data<'a>> {
-        Data::from_seekable_reader(Cursor::new(self)).map_err(|e| e.error())
+        Data::from_seekable_stream(Cursor::new(self)).map_err(|e| e.error())
     }
 }
 
@@ -578,7 +578,7 @@ impl<'a> IntoData<'a> for &'a mut Vec<u8> {
     type Output = Data<'a>;
 
     fn into_data(self) -> Result<Data<'a>> {
-        self.as_mut_slice().into_data()
+        Data::from_seekable_stream(Cursor::new(self)).map_err(|e| e.error())
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -558,6 +558,14 @@ impl<'a> IntoData<'a> for &'a [u8] {
     }
 }
 
+impl<'a> IntoData<'a> for &'a mut [u8] {
+    type Output = Data<'a>;
+
+    fn into_data(self) -> Result<Data<'a>> {
+        Data::from_seekable_reader(Cursor::new(self)).map_err(|e| e.error())
+    }
+}
+
 impl<'a> IntoData<'a> for &'a Vec<u8> {
     type Output = Data<'a>;
 
@@ -570,7 +578,7 @@ impl<'a> IntoData<'a> for &'a mut Vec<u8> {
     type Output = Data<'a>;
 
     fn into_data(self) -> Result<Data<'a>> {
-        Data::from_seekable_stream(Cursor::new(self)).map_err(|e| e.error())
+        self.as_mut_slice().into_data()
     }
 }
 


### PR DESCRIPTION
This also implements `IntoData` for `&mut [u8]`. Useful when other bits return a `&mut [u8]` instead of `&mut Vec<u8>`.

Please validate whether this implementation is correct, I'm not 100% sure.