### PR TITLE
Fix with_passphrase_provider example

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -286,7 +286,7 @@ impl Context {
     ///
     /// use gpgme::{Context, PassphraseRequest, Protocol};
     ///
-    /// let mut ctx = Context::from_protocol(Protocol::OpenPgp)?;
+    /// let mut ctx = Context::from_protocol(Protocol::OpenPgp).unwrap();
     /// ctx.with_passphrase_provider(|_: PassphraseRequest, out: &mut dyn Write| {
     ///     out.write_all(b"some passphrase")?;
     ///     Ok(())


### PR DESCRIPTION
Current example doesn't work and return : Error[E0599]: no method named `with_passphrase_provider` found for enum `std::result::Result<gpgme::Context, gpgme::Error>` in the current scope. 

Propose a working fix according to what we can find in the test directory