### PR TITLE
Replace tempdir with tempfile, as tempfile have superseded tempdir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ maintenance = { status = "experimental" }
 
 [dev-dependencies]
 structopt = "0.3"
-tempdir = "0.3"
+tempfile = "3"
 
 [dependencies]
 bitflags = "1"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,8 +10,6 @@ use std::{
     },
 };
 
-use tempdir::TempDir;
-
 use gpgme::{self, Context, PassphraseRequest, PinentryMode};
 
 macro_rules! count {
@@ -98,12 +96,12 @@ fn setup_agent(dir: &Path) {
 
 pub struct TestCase {
     count: AtomicUsize,
-    homedir: RwLock<Option<TempDir>>,
+    homedir: RwLock<Option<tempfile::TempDir>>,
 }
 
 impl TestCase {
     pub fn new(count: usize) -> TestCase {
-        let dir = TempDir::new(".test-gpgme").unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
         setup_agent(dir.path());
         import_key(include_bytes!("./data/pubdemo.asc"));
         import_key(include_bytes!("./data/secdemo.asc"));


### PR DESCRIPTION
Not tested as well as I would have liked, due to that i had some compilation errors unrelated to this pr.

Based on the patch i wrote for debian:

https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/gpgme/debian/patches/replace-tempdir-with-tempfile.patch

The deprecation of tempdir can be seen here: https://crates.io/crates/tempdir