### PR TITLE
doc: Fix apt-get install libgpgme-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ them (or the registry on Windows).
 
 On Debian/Ubuntu based systems:
 ```sh
-$ sudo apt-get install libgpgme11-dev
+$ sudo apt-get install libgpgme-dev
 ```
 
 On Fedora/RHEL based systems:


### PR DESCRIPTION
It is renamed since Ubuntu Xenial. Note that `libgpgme-dev` installs the `libgpgme11` dependency. For example:

* https://packages.ubuntu.com/jammy/libgpgme-dev
* https://packages.debian.org/sid/libgpgme-dev